### PR TITLE
18th yuji sakamoto

### DIFF
--- a/workshop/18th/yuji-sakamoto/app/README.md
+++ b/workshop/18th/yuji-sakamoto/app/README.md
@@ -16,6 +16,8 @@
 8. 参考サイト：https://mavlink.io/en/messages/common.html
 9. 参考サイト：https://ardupilot.org/dev/docs/copter-commands-in-guided-mode.html
 10. 実機テスト動画：https://www.instagram.com/p/DDq2LVBSSes/
+11. 強風対策後実機テスト動画：https://www.instagram.com/p/DEC0mtiSUyR/
+
 
 #### テスト手順（SITL）
 1. WSL上でSITLを起動

--- a/workshop/18th/yuji-sakamoto/app/README.md
+++ b/workshop/18th/yuji-sakamoto/app/README.md
@@ -30,7 +30,7 @@
 3. rc.pyでmavlink-routerdでFCとUART接続しているのでUDP転送ポートに接続してflight()を0.2秒周期で呼び出す
 4. プロポでstabilize->guidedに切り替える
 5. スクエア飛行実行
-6. guided切り替え時に高度情報が異常の場合はリブートする
+6. guided切り替え時に高度情報が異常の場合は警告音後実行しない
 7. guided切り替え後にARMできない場合は警告音後実行しない
 
 ## syakyo

--- a/workshop/18th/yuji-sakamoto/app/README.md
+++ b/workshop/18th/yuji-sakamoto/app/README.md
@@ -11,21 +11,38 @@
 3. flight()は0.2秒周期で呼び出される前提で状態遷移させて制御する※0.2秒の根拠は実験の結果モード変化検出できる最長時間のため
 4. 離陸して目標高度に達した時の判定、旋回完了判定、直進完了判定は共通関数isStable()で実施
 5. isStable()はGLOBAL_POSITION_INTメッセージのvx/vy/vzによる速度が0付近になったこととrelative_altの変化がなくなったこと、および、hdgによるヨーの変化がなくなったことによる判定を行っている
-6. isStable()による「安定判定」を厳しくするとなかなか安定判定とならないため実機による実験で緩めの設定に変更している
-7. 参考サイト：https://mavlink.io/en/mavgen_python/howto_requestmessages.html
-8. 参考サイト：https://mavlink.io/en/messages/common.html
-9. 参考サイト：https://ardupilot.org/dev/docs/copter-commands-in-guided-mode.html
-10. 実機テスト動画：https://www.instagram.com/p/DDq2LVBSSes/
-11. 強風対策後実機テスト動画：https://www.instagram.com/p/DEC0mtiSUyR/
+6. isStable()による「安定判定」を厳しくするとなかなか安定判定とならないため実機による実験で緩めの設定に変更
+7. 強風対策のためisStable()の「安定判定」は時間軸によるリトライアウトを設ける
+8. 強風対策のため機首の向きが変わらないように安定判定中とホバリング中は周期的にYAWを補正するように制御する
+9. 参考サイト：https://mavlink.io/en/mavgen_python/howto_requestmessages.html
+10. 参考サイト：https://mavlink.io/en/messages/common.html
+11. 参考サイト：https://ardupilot.org/dev/docs/copter-commands-in-guided-mode.html
+12. 実機テスト動画：https://www.instagram.com/p/DDq2LVBSSes/
+13. 強風対策後実機テスト動画：https://www.instagram.com/p/DEC0mtiSUyR/
 
+#### 動作環境パッケージインストール手順
+1. Windows環境でMission Plannerセットアップ：https://firmware.ardupilot.org/Tools/MissionPlanner/MissionPlanner-latest.msiをインストール
+2. Ubuntu-22.04@WSLをインストール（手順割愛）
+3. Visual Studio Codeのインストールと環境設定は動作確認自体には不要
+4. ArduPilotビルド環境セットアップ１（Ubuntu@WSLターミナルの特定のフォルダで「git clone https://github.com/ArduPilot/ardupilot.git」実行）
+5. ArduPilotビルド環境セットアップ２（Ubuntu@WSLフォルターミナルでgit cloneしたフォルダで「./Tools/environment_install/install-prereqs-ubuntu.sh -y」実行）
+6. 5.で.bashrcの修正とPATH設定が行われるので新しいUbuntu@WSLターミナルを開くかターミナルを開きなおす
+7. SITLセットアップ（Ubuntu@WSLターミナルでSITL実行環境用のフォルダを作成（そのフォルダにログなどが出力されるため~/SITLなど任意））
+8. 7.のフォルダに移動して「sim_vehicle.py -v Copter --map --console -L Kawachi」実行
+9. SITL起動したUbuntu@WSLとは別のターミナルを開く
+10. square.py取得（9.のUbuntu@WSLターミナルの任意のフォルダで「wget https://raw.githubusercontent.com/pff01210/droneschool/refs/heads/18th_yuji-sakamoto/workshop/18th/yuji-sakamoto/app/flight_experience/square.py」実行）
+11. 10.のフォルダで「$ python square.py」実行でSITLと接続して実行開始可能
 
 #### テスト手順（SITL）
-1. WSL上でSITLを起動
-2. WSL上でpython square.py実行
-3. Windows上でMP起動して1.のSITLと接続（動作モニター用）
-4. 1.のSITLよりコマンド入力：(mode stabilize->mode guided)でスクエア飛行実行
+1. Ubuntu@WSLターミナルを開き（ターミナル１）SITLを起動
+2. 別のUbuntu@WSLターミナルを開き（ターミナル２）square.pyを保存したフォルダで「python square.py」実行
+3. Windows上でMP起動してターミナル１のSITLと接続（動作モニター用）
+4. ターミナル１のSITLよりコマンド入力(mode stabilize実行後mode guided実行)するとスクエア飛行実行開始される
+5. 4.実行中、ターミナル２ではログにより動作状況が出力されている
+6. 4.実行中、MPでは動作状況が表示される（移動距離が少ないのでマップはズームインで確認推奨）
 
-#### テスト手順（実機）
+
+#### テスト手順（実機）※参考
 0. http://10.0.2.100:3000/controllerで[Start Telemetry]しておく
 1. ラズベリーパイのrc.local->rc.py->square.pyを実行
 2. rc.pyではfrom app.flight_experience.square import flight

--- a/workshop/18th/yuji-sakamoto/app/README.md
+++ b/workshop/18th/yuji-sakamoto/app/README.md
@@ -19,6 +19,7 @@
 11. 参考サイト：https://ardupilot.org/dev/docs/copter-commands-in-guided-mode.html
 12. 実機テスト動画：https://www.instagram.com/p/DDq2LVBSSes/
 13. 強風対策後実機テスト動画：https://www.instagram.com/p/DEC0mtiSUyR/
+14. 強風対策後強風時実機テスト動画：https://www.instagram.com/p/DEbDB-nzPCr/
 
 #### 動作環境パッケージインストール手順
 1. Windows環境でMission Plannerセットアップ：https://firmware.ardupilot.org/Tools/MissionPlanner/MissionPlanner-latest.msiをインストール

--- a/workshop/18th/yuji-sakamoto/fc/Lua/force-change-simple.lua
+++ b/workshop/18th/yuji-sakamoto/fc/Lua/force-change-simple.lua
@@ -25,9 +25,9 @@ local extend_mode = true
 -- the main update function
 function update()
     pwm8 = rc:get_pwm(8)
+    local mode = vehicle:get_mode()                   -- get current mode
     if extend_mode and pwm8 and pwm8 > 1500 then
       -- RC 8 がONの時のみ有効化
-      local mode = vehicle:get_mode()                   -- get current mode
       if mode == MODE_ALT_HOLD then
         -- ALT_HOLDならALT_HOLD_SIMPLEにモード変更する
         extend_mode = vehicle:set_mode(MODE_ALT_HOLD_SIMPLE)
@@ -36,18 +36,16 @@ function update()
           prior_mode = mode
           prior_mode_name = "ALT_HOLD"
         end
-      else
-        if mode == MODE_LOITER then
-          -- LOITERならLOITER_SUPERSIMPLEにモード変更する
-          extend_mode = vehicle:set_mode(MODE_LOITER_SUPERSIMPLE)
-          if extend_mode then
-            gcs:send_text(MAV_SEVERITY.INFO, "Lua : LOITER -> LOITER_SUPERSIMPLE")
-            prior_mode = mode
-            prior_mode_name = "LOITER"
-          end
+      elseif mode == MODE_LOITER then
+        -- LOITERならLOITER_SUPERSIMPLEにモード変更する
+        extend_mode = vehicle:set_mode(MODE_LOITER_SUPERSIMPLE)
+        if extend_mode then
+          gcs:send_text(MAV_SEVERITY.INFO, "Lua : LOITER -> LOITER_SUPERSIMPLE")
+          prior_mode = mode
+          prior_mode_name = "LOITER"
         end
       end
-    else
+    elseif mode == MODE_ALT_HOLD_SIMPLE or mode == MODE_LOITER_SUPERSIMPLE then
       if prior_mode > 0 then
         -- RC 8 がOFFの時切り替え済みの場合は切り替え前のモードに戻す
         gcs:send_text(MAV_SEVERITY.INFO, "Lua : RESET to " .. prior_mode_name)


### PR DESCRIPTION
# コース２：Day4フライトエクスペリエンス時完走できなかった問題修正
## ARM前の高度情報チェックが異常時にフライト実行しない処理時に警告音を鳴らすように機能追加
## 離陸、着陸、旋回、直進制御時安定判定を行っているが強風で安定判定できない場合にリトライアウトで次に進めるように修正
## 安定判定前後の待ち時間設定値を移動距離などで可変設定するように修正
## 強風で機首の向きが変わったので変わらないように機首の向きを維持する制御処理追加

# コース２：フライトエクスペリエンス用スクリプト説明用README.md修正
## テスト環境構築説明追加
## テスト手順内容修正
## 機首安定処理後の実機テスト動画URL追加

# コース３：フライトコードモード追加ワークショップ修正内容が実機wafビルドでエラーになるので修正

